### PR TITLE
Adding support to cgal4h to build without linking to libs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,19 +2,21 @@ Package: laridae
 Type: Package
 Title: CGAL Experiments in Topology
 Version: 0.0.2
-Authors@R: c(    
+Authors@R: c(
     person("Michael D.", "Sumner", , "mdsumner@gmail.com", c("aut", "cre")),
     person("Mark", "Padgham", role=c("ctb")))
 Description: Experimental wrapper for CGAL to explore constrained triangulations and
-   general edge-decomposition structures for shapes. 
-LinkingTo: Rcpp
-Imports: 
+   general edge-decomposition structures for shapes.
+LinkingTo:
+    Rcpp,
+    cgal4h
+Imports:
     Rcpp,
     silicate
 License: LGPL-3
 LazyData: TRUE
 Remotes: mdsumner/gris
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 RcppModules: Shape
 Roxygen: list(markdown = TRUE)
 ByteCompile: true

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,7 @@
 
-CGAL_LIBS   = -L/usr/lib -lmpfr -lgmp -lCGAL -lboost_thread -lboost_system -lpthread -lCGAL -lboost_thread -lboost_system -lpthread
+CGAL_LIBS   = -L/usr/lib -lmpfr -lgmp -lboost_thread -lboost_system -lpthread -lboost_thread -lboost_system -lpthread
 
 # combine with standard arguments for R
 PKG_LIBS = $(CGAL_LIBS) $(RCPP_LDFLAGS)
+
+PKG_CXXFLAGS = -DCGAL_HEADER_ONLY=1


### PR DESCRIPTION
Hi @mdsumner ,

I finally got cgal4h on CRAN and if you want to use the header version of CGAL to build your package, I made some minor changes and added cgal4h as dependency.
I would love to see how we can implement a sf friendly constrained triangulation using CGAL like your work on sfdct.

Thanks again,
Ahmadou